### PR TITLE
There's a missing ")" at line 103

### DIFF
--- a/aoz/languages/v1_0/sprites/sprites.aoz
+++ b/aoz/languages/v1_0/sprites/sprites.aoz
@@ -100,7 +100,7 @@
 			this.aoz.spritesContext.parseAll( contextName, function( sprite )
 			{
 				done |= sprite.update( { force: force } );
-			};
+			} );
 			if ( done )
 			{
 				this.sortSpritesPriority();


### PR DESCRIPTION
This was causing runtime errors, as reported Bug #101